### PR TITLE
[wc] Fix clippy warning

### DIFF
--- a/src/wc/main.rs
+++ b/src/wc/main.rs
@@ -67,7 +67,7 @@ fn main() {
         stats.push(stat);
     } else {
         for filename in &args.files {
-            let file = match File::open(&filename) {
+            let file = match File::open(filename) {
                 Err(why) => panic!("couldn't open: {}", why),
                 Ok(file) => file,
             };


### PR DESCRIPTION
Fix a clippy warning, possibly new with the latest Rust stable release, so that the bsum work can pass.